### PR TITLE
fix: out of memory on firestore trigger functions

### DIFF
--- a/functions/src/v2/firestore/scope/user/blockchain/multisig/cosigner/onDocumentWritten.ts
+++ b/functions/src/v2/firestore/scope/user/blockchain/multisig/cosigner/onDocumentWritten.ts
@@ -16,7 +16,7 @@ setFunctionsV2DefaultGlobalOption(
   {
     region: 'asia-northeast1',
     timeoutSeconds: 60,
-    memory: '128MiB',
+    memory: '256MiB',
   },
   functionsV2,
 );

--- a/functions/src/v2/firestore/scope/user/blockchain/multisig/onDocumentWritten.ts
+++ b/functions/src/v2/firestore/scope/user/blockchain/multisig/onDocumentWritten.ts
@@ -16,7 +16,7 @@ setFunctionsV2DefaultGlobalOption(
   {
     region: 'asia-northeast1',
     timeoutSeconds: 60,
-    memory: '128MiB',
+    memory: '256MiB',
   },
   functionsV2,
 );

--- a/functions/src/v2/firestore/scope/user/onDocumentWritten.ts
+++ b/functions/src/v2/firestore/scope/user/onDocumentWritten.ts
@@ -16,7 +16,7 @@ setFunctionsV2DefaultGlobalOption(
   {
     region: 'asia-northeast1',
     timeoutSeconds: 60,
-    memory: '128MiB',
+    memory: '256MiB',
   },
   functionsV2,
 );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
	- Increased memory allocation for certain Firestore functions, enhancing their performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->